### PR TITLE
fix: stop Commander.js from consuming wrapped command flags

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -62,6 +62,7 @@ async function main(): Promise<void> {
       parseInt,
     )
     .allowUnknownOption()
+    .passThroughOptions()
     .action(
       async (
         commandArgs: string[],

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,5 +1,7 @@
 import { describe, test, expect } from 'bun:test'
 import { spawnSync } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
 import { join } from 'node:path'
 
 /**
@@ -96,6 +98,50 @@ describe('CLI', () => {
       const result = runCli(['echo', '-n', 'no newline'])
       // -n flag to echo suppresses newline
       expect(result.stdout).toBe('no newline')
+      expect(result.status).toBe(0)
+    })
+  })
+
+  describe('option passthrough to wrapped commands', () => {
+    test('does not consume -s flag from wrapped command', () => {
+      // Regression: -s is SRT's --settings shorthand, but after the command
+      // name it should pass through to the wrapped command, not be parsed
+      const result = runCli(['echo', '-s', 'silent'])
+      expect(result.stdout.trim()).toBe('-s silent')
+      expect(result.status).toBe(0)
+    })
+
+    test('does not consume -d flag from wrapped command', () => {
+      // -d is SRT's --debug shorthand, but after the command name it should
+      // pass through
+      const result = runCli(['echo', '-d', 'debug'])
+      expect(result.stdout.trim()).toBe('-d debug')
+      expect(result.status).toBe(0)
+    })
+
+    test('SRT -s/--settings still works before command', () => {
+      // SRT's own -s should still be parsed when it appears before the
+      // wrapped command. Use a real config file to avoid silent-fallback issues.
+      const tmpDir = fs.mkdtempSync(join(os.tmpdir(), 'srt-test-'))
+      const configPath = join(tmpDir, 'config.json')
+      const validConfig = {
+        network: { allowedDomains: [], deniedDomains: [] },
+        filesystem: { denyRead: [], allowWrite: [], denyWrite: [] },
+      }
+      fs.writeFileSync(configPath, JSON.stringify(validConfig))
+
+      try {
+        const result = runCli(['-s', configPath, 'echo', 'hello'])
+        expect(result.stdout.trim()).toBe('hello')
+        expect(result.status).toBe(0)
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true })
+      }
+    })
+
+    test('-- separator still works for backwards compatibility', () => {
+      const result = runCli(['--', 'echo', '-s', 'test'])
+      expect(result.stdout.trim()).toBe('-s test')
       expect(result.status).toBe(0)
     })
   })


### PR DESCRIPTION
## Summary

Add `.passThroughOptions()` to the Commander.js program definition so SRT stops parsing options after the first positional argument (the wrapped command name).

Without this, Commander.js consumes known short flags like `-s` (`--settings`) and `-d` (`--debug`) even when they appear in the wrapped command (e.g., `curl -s`), silently stealing them from the child process.

Closes #1

## Changes

- Add `.passThroughOptions()` alongside existing `.allowUnknownOption()` in `src/cli.ts`
- Add 4 regression tests in `test/cli.test.ts`:
  - `-s` in wrapped command passes through (core bug)
  - `-d` in wrapped command passes through
  - SRT's own `-s`/`--settings` still works when placed before the command
  - `--` separator remains backwards-compatible

## Testing

- All 19 CLI tests pass (`bun test test/cli.test.ts`)
- `bun run lint:check` passes
- `bun run typecheck` passes
- Manual verification:
  - `srt echo -s silent` → outputs `-s silent` (previously consumed by SRT)
  - `srt -s /dev/null echo hello` → outputs `hello` (SRT flag still works)
  - `srt -- echo -s test` → outputs `-s test` (backwards compat)