### PR TITLE
fix: fail on explicit --settings path and fix --debug flag

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -75,7 +75,7 @@ async function main(): Promise<void> {
         try {
           // Enable debug logging if requested
           if (options.debug) {
-            process.env.DEBUG = 'true'
+            process.env.SRT_DEBUG = 'true'
           }
 
           // Load config from file
@@ -83,6 +83,11 @@ async function main(): Promise<void> {
           let runtimeConfig = loadConfig(configPath)
 
           if (!runtimeConfig) {
+            if (options.settings) {
+              // Explicit config path failed — refuse to run with silent defaults
+              console.error(`Error: Failed to load config from ${configPath}`)
+              process.exit(1)
+            }
             logForDebugging(
               `No config found at ${configPath}, using default config`,
             )

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -114,6 +114,74 @@ describe('CLI', () => {
     })
   })
 
+  describe('config loading safety', () => {
+    test('exits with error when --settings points to nonexistent file', () => {
+      const result = runCli([
+        '--settings',
+        '/nonexistent/path/settings.json',
+        'echo',
+        'hello',
+      ])
+      expect(result.stderr).toContain('/nonexistent/path/settings.json')
+      expect(result.status).toBe(1)
+      // Command should NOT execute
+      expect(result.stdout).not.toContain('hello')
+    })
+
+    test('exits with error when -s points to nonexistent file', () => {
+      const result = runCli([
+        '-s',
+        '/nonexistent/path/settings.json',
+        'echo',
+        'hello',
+      ])
+      expect(result.stderr).toContain('/nonexistent/path/settings.json')
+      expect(result.status).toBe(1)
+    })
+
+    test('falls back to defaults when no --settings provided and default path missing', () => {
+      // HOME is set to /tmp/cli-test-nonexistent by runCli, so
+      // ~/.srt-settings.json does not exist — this is the first-time user case
+      const result = runCli(['echo', 'hello'])
+      expect(result.stdout.trim()).toBe('hello')
+      expect(result.status).toBe(0)
+    })
+  })
+
+  describe('--debug flag enables SRT_DEBUG logging', () => {
+    test('--debug flag produces debug output', () => {
+      const result = spawnSync(
+        'bun',
+        ['run', getCliPath(), '--debug', 'echo', 'test'],
+        {
+          encoding: 'utf-8',
+          env: {
+            ...process.env,
+            HOME: '/tmp/cli-test-nonexistent',
+          },
+        },
+      )
+      expect(result.stderr).toContain('[SandboxDebug]')
+      expect(result.status).toBe(0)
+    })
+
+    test('-d flag produces debug output', () => {
+      const result = spawnSync(
+        'bun',
+        ['run', getCliPath(), '-d', 'echo', 'test'],
+        {
+          encoding: 'utf-8',
+          env: {
+            ...process.env,
+            HOME: '/tmp/cli-test-nonexistent',
+          },
+        },
+      )
+      expect(result.stderr).toContain('[SandboxDebug]')
+      expect(result.status).toBe(0)
+    })
+  })
+
   describe('debug output', () => {
     test('SRT_DEBUG enables debug output for positional args', () => {
       const result = runCli(['echo', 'test'], { debug: true })


### PR DESCRIPTION
## Summary

Two fixes for silent failure modes that can cause the sandbox to fail open:

1. **Explicit `--settings` path now fails hard.** When `--settings` points to a nonexistent or invalid config, SRT exits with an error instead of silently falling back to `getDefaultConfig()` where `denyRead: []` disables all filesystem read restrictions. The default-path fallback for first-time users (no `--settings` flag) is preserved.

2. **`--debug` flag now actually works.** The flag set `process.env.DEBUG` but `logForDebugging()` checks `process.env.SRT_DEBUG`. Fixed to set the correct variable.

Closes #3

## Changes

- `src/cli.ts` line 78: `process.env.DEBUG` → `process.env.SRT_DEBUG`
- `src/cli.ts` lines 86-90: Add conditional — if `options.settings` was explicitly provided and `loadConfig` returned null, exit 1 with error message instead of falling back to defaults

## Testing

- 20/20 CLI tests pass (`bun test test/cli.test.ts`)
- `bun run lint:check` passes
- `bun run typecheck` passes
- 5 new tests:
  - `--settings /nonexistent` → exits 1 with error on stderr
  - `-s /nonexistent` → exits 1 with error on stderr
  - No `--settings` with missing default → still falls back to defaults (first-time user path preserved)
  - `--debug` flag → produces `[SandboxDebug]` output
  - `-d` flag → produces `[SandboxDebug]` output
- Red-green verified: all 4 new failure-mode tests failed before the fix, pass after